### PR TITLE
Use data loader in real-time simulation engine

### DIFF
--- a/gal_friday/simulated_market_price_service.py
+++ b/gal_friday/simulated_market_price_service.py
@@ -8,6 +8,7 @@ It also supports volatility-adjusted spread calculation and market depth simulat
 """
 
 import logging
+import dataclasses
 from dataclasses import dataclass, field
 from datetime import UTC, datetime, timedelta
 from decimal import ROUND_DOWN, ROUND_UP, Decimal
@@ -679,9 +680,10 @@ class SimulationError(Exception):
 
 class RealTimeSimulationEngine:
     """Enterprise-grade real-time price simulation engine"""
-    
-    def __init__(self, config: Dict[str, Any]):
+
+    def __init__(self, config: Dict[str, Any], data_loader: "HistoricalDataLoader"):
         self.config = config
+        self._data_loader = data_loader
         self.logger = logging.getLogger(__name__)
         
         # Simulation state
@@ -876,9 +878,20 @@ class RealTimeSimulationEngine:
     
     async def _load_historical_data(self, symbol: str) -> List[dict]:
         """Load historical data for a symbol"""
-        # This would integrate with the historical data loader
-        # For now, return empty list
-        return []
+        try:
+            request = DataRequest(
+                symbol=symbol,
+                start_date=self.config["start_time"],
+                end_date=self.config["end_time"],
+                frequency=self.config.get("frequency", "1h"),
+            )
+
+            points = await self._data_loader.load_historical_data(request)
+            return [dataclasses.asdict(p) for p in points]
+
+        except Exception as e:
+            self.logger.error(f"Failed to load historical data for {symbol}: {e}")
+            return []
     
     def _calculate_speed_multiplier(self) -> float:
         """Calculate speed multiplier based on configuration"""
@@ -993,7 +1006,10 @@ class SimulatedMarketPriceService(MarketPriceService):  # Inherit from MarketPri
             'start_time': datetime.now(UTC),
             'end_time': datetime.now(UTC) + timedelta(days=1)
         }
-        self._simulation_engine = RealTimeSimulationEngine(simulation_config)
+        self._simulation_engine = RealTimeSimulationEngine(
+            simulation_config,
+            self._data_loader,
+        )
         
         # Register price update handler for simulation engine
         self._simulation_engine.register_event_handler('price_update', self._handle_price_update_event)

--- a/tests/unit/test_real_time_simulation_engine.py
+++ b/tests/unit/test_real_time_simulation_engine.py
@@ -1,0 +1,36 @@
+import asyncio
+from datetime import datetime, timedelta, UTC
+import heapq
+import pytest
+
+from gal_friday.simulated_market_price_service import (
+    RealTimeSimulationEngine,
+    HistoricalDataPoint,
+    DataRequest,
+)
+
+class DummyLoader:
+    async def load_historical_data(self, request: DataRequest):
+        start = request.start_date
+        return [
+            HistoricalDataPoint(start, request.symbol, 1, 1, 1, 1, 1),
+            HistoricalDataPoint(start + timedelta(minutes=1), request.symbol, 2, 2, 2, 2, 2),
+        ]
+
+@pytest.mark.asyncio
+async def test_simulation_engine_populates_events_with_historical_data():
+    start = datetime(2021, 1, 1, tzinfo=UTC)
+    end = start + timedelta(minutes=2)
+    config = {
+        'symbols': ['BTC/USD'],
+        'start_time': start,
+        'end_time': end,
+        'frequency': '1m',
+    }
+    engine = RealTimeSimulationEngine(config, DummyLoader())
+    await engine._load_simulation_data()
+
+    assert len(engine.event_queue) == 2
+    first_event = heapq.heappop(engine.event_queue)
+    assert isinstance(first_event.data['price_data'], dict)
+    assert first_event.timestamp == start


### PR DESCRIPTION
## Summary
- allow `RealTimeSimulationEngine` to accept a `HistoricalDataLoader`
- create `DataRequest` from engine config and convert returned points
- wire up `SimulatedMarketPriceService` with the loader
- test that events populate when historical data is present

## Testing
- `pytest tests/unit/test_real_time_simulation_engine.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6849d5e449c48326bc238fff3ef90923