### PR TITLE
Implement provider selection for HistoricalDataLoader

### DIFF
--- a/gal_friday/simulated_market_price_service.py
+++ b/gal_friday/simulated_market_price_service.py
@@ -274,11 +274,34 @@ class HistoricalDataLoader:
     
     async def _load_from_provider(self, request: DataRequest) -> List[HistoricalDataPoint]:
         """Load data from appropriate provider"""
-        self.cache_stats['provider_requests'] += 1
-        
-        # For now, return empty list - would integrate with actual providers
-        # In real implementation, this would fetch from external data sources
-        return []
+        provider: HistoricalDataProvider | None = None
+
+        if request.data_source is not None:
+            provider = self.providers.get(request.data_source)
+            if provider is None:
+                raise DataLoadingError(
+                    f"No provider configured for data source: {request.data_source}"
+                )
+        else:
+            for candidate in self.providers.values():
+                try:
+                    if await candidate.validate_symbol(request.symbol):
+                        provider = candidate
+                        break
+                except Exception as exc:  # pragma: no cover - defensive
+                    self.logger.error("Provider validation failed: %s", exc)
+
+        if provider is None:
+            raise DataLoadingError(
+                f"No provider available for symbol: {request.symbol}"
+            )
+
+        self.cache_stats["provider_requests"] += 1
+
+        try:
+            return await provider.fetch_data(request)
+        except Exception as exc:  # pragma: no cover - wrap and rethrow
+            raise DataLoadingError(str(exc)) from exc
     
     def _generate_cache_key(self, request: DataRequest) -> str:
         """Generate unique cache key for request"""

--- a/tests/unit/test_historical_data_loader.py
+++ b/tests/unit/test_historical_data_loader.py
@@ -1,0 +1,130 @@
+"""Tests for HistoricalDataLoader provider selection and error handling."""
+
+from datetime import datetime
+from typing import List
+
+import pytest
+
+from gal_friday.simulated_market_price_service import (
+    DataRequest,
+    DataSource,
+    HistoricalDataLoader,
+    HistoricalDataPoint,
+    HistoricalDataProvider,
+    DataLoadingError,
+)
+
+
+class MockProvider(HistoricalDataProvider):
+    """Simple provider used for testing."""
+
+    def __init__(self, symbols: list[str], result: List[HistoricalDataPoint], *, raise_error: bool = False) -> None:
+        self.symbols = symbols
+        self.result = result
+        self.raise_error = raise_error
+        self.fetch_called = 0
+        self.validate_called = 0
+
+    async def fetch_data(self, request: DataRequest) -> List[HistoricalDataPoint]:
+        self.fetch_called += 1
+        if self.raise_error:
+            raise ValueError("failed")
+        return self.result
+
+    async def validate_symbol(self, symbol: str) -> bool:
+        self.validate_called += 1
+        return symbol in self.symbols
+
+
+@pytest.mark.asyncio()
+async def test_select_by_data_source() -> None:
+    """Provider is chosen based on request.data_source."""
+    data = [HistoricalDataPoint(datetime.utcnow(), "BTC", 1, 1, 1, 1, 1)]
+    p1 = MockProvider(["ETH"], [])
+    p2 = MockProvider(["BTC"], data)
+
+    loader = HistoricalDataLoader({})
+    loader.providers = {DataSource.YAHOO_FINANCE: p1, DataSource.KRAKEN: p2}
+
+    request = DataRequest(
+        symbol="BTC",
+        start_date=datetime.utcnow(),
+        end_date=datetime.utcnow(),
+        frequency="1m",
+        data_source=DataSource.KRAKEN,
+    )
+
+    result = await loader._load_from_provider(request)
+
+    assert result == data
+    assert p2.fetch_called == 1
+    assert loader.cache_stats["provider_requests"] == 1
+    assert p1.fetch_called == 0
+
+
+@pytest.mark.asyncio()
+async def test_auto_provider_selection() -> None:
+    """First provider validating the symbol is used when data_source is None."""
+    data = [HistoricalDataPoint(datetime.utcnow(), "BTC", 1, 1, 1, 1, 1)]
+    p1 = MockProvider(["ETH"], [])
+    p2 = MockProvider(["BTC"], data)
+
+    loader = HistoricalDataLoader({})
+    loader.providers = {DataSource.YAHOO_FINANCE: p1, DataSource.KRAKEN: p2}
+
+    request = DataRequest(
+        symbol="BTC",
+        start_date=datetime.utcnow(),
+        end_date=datetime.utcnow(),
+        frequency="1m",
+    )
+
+    result = await loader._load_from_provider(request)
+
+    assert result == data
+    assert p2.fetch_called == 1
+    assert p1.fetch_called == 0
+    assert p1.validate_called == 1
+    assert loader.cache_stats["provider_requests"] == 1
+
+
+@pytest.mark.asyncio()
+async def test_missing_provider_raises() -> None:
+    """DataLoadingError is raised when no provider is found."""
+    loader = HistoricalDataLoader({})
+    loader.providers = {}
+
+    request = DataRequest(
+        symbol="BTC",
+        start_date=datetime.utcnow(),
+        end_date=datetime.utcnow(),
+        frequency="1m",
+        data_source=DataSource.KRAKEN,
+    )
+
+    with pytest.raises(DataLoadingError):
+        await loader._load_from_provider(request)
+
+    assert loader.cache_stats["provider_requests"] == 0
+
+
+@pytest.mark.asyncio()
+async def test_fetch_error_wrapped() -> None:
+    """Errors from provider.fetch_data are wrapped in DataLoadingError."""
+    p = MockProvider(["BTC"], [], raise_error=True)
+    loader = HistoricalDataLoader({})
+    loader.providers = {DataSource.KRAKEN: p}
+
+    request = DataRequest(
+        symbol="BTC",
+        start_date=datetime.utcnow(),
+        end_date=datetime.utcnow(),
+        frequency="1m",
+        data_source=DataSource.KRAKEN,
+    )
+
+    with pytest.raises(DataLoadingError):
+        await loader._load_from_provider(request)
+
+    assert loader.cache_stats["provider_requests"] == 1
+


### PR DESCRIPTION
## Summary
- implement provider selection logic in `HistoricalDataLoader`
- add unit tests covering provider choice and error handling

## Testing
- `pip install pandas`
- `pip install pytest-asyncio`
- `pytest tests/unit/test_historical_data_loader.py`

------
https://chatgpt.com/codex/tasks/task_e_6849d5e273e483268f9d4f92da996f7b