### PR TITLE
Implement feature value imputation

### DIFF
--- a/tests/unit/test_prediction_service_feature_imputation.py
+++ b/tests/unit/test_prediction_service_feature_imputation.py
@@ -1,0 +1,32 @@
+"""Unit tests for PredictionService feature imputation logic."""
+
+from unittest.mock import MagicMock
+
+import numpy as np
+
+from gal_friday.prediction_service import PredictionService
+
+NEUTRAL_RSI = 50.0
+
+
+class TestPrepareFeaturesForModelImputation:
+    """Tests for the `_prepare_features_for_model` helper."""
+
+    def setup_method(self) -> None:
+        """Create a minimal PredictionService instance for testing."""
+        self.service = PredictionService(
+            config={"prediction_service": {"models": []}},
+            pubsub_manager=MagicMock(),
+            process_pool_executor=MagicMock(),
+            logger_service=MagicMock(),
+        )
+
+    def test_nan_value_imputed(self) -> None:
+        """Ensure NaN inputs are replaced with contextual defaults."""
+        features = {"rsi_14_default": np.nan}
+        expected = ["rsi_14_default"]
+        result = self.service._prepare_features_for_model(features, expected)
+
+        assert result is not None
+        assert isinstance(result, np.ndarray)
+        assert result[0] == NEUTRAL_RSI


### PR DESCRIPTION
## Summary
- impute missing or NaN feature values rather than passing `np.nan`
- add helper `_impute_feature_value` in prediction service
- unit test for new imputation logic

## Testing
- `ruff check gal_friday/prediction_service.py tests/unit/test_prediction_service_feature_imputation.py`
- `mypy gal_friday/prediction_service.py tests/unit/test_prediction_service_feature_imputation.py` *(fails: sqlalchemy stubs missing)*
- `pytest -q tests/unit/test_prediction_service_feature_imputation.py` *(fails: ModuleNotFoundError: 'yaml')*


------
https://chatgpt.com/codex/tasks/task_e_6849e60646888326ba5d54685147ac6c