### PR TITLE
Add volatility adjusted interpolation

### DIFF
--- a/tests/unit/test_gap_interpolator.py
+++ b/tests/unit/test_gap_interpolator.py
@@ -3,6 +3,7 @@ import sys
 import types
 from datetime import UTC, timedelta
 from pathlib import Path
+import pytest
 
 import numpy as np
 import pandas as pd
@@ -43,14 +44,15 @@ def _create_interpolator(logger):
     return DataInterpolator(config, logger)
 
 
-def _sample_data(start, periods, slope=1.0):
+def _sample_data(start, periods, slope=1.0, vol=0.5):
+    """Create simple OHLCV test data with configurable volatility."""
     times = pd.date_range(start, periods=periods, freq="1min", tz=UTC)
     base = np.arange(periods, dtype=float) * slope + 100
     data = pd.DataFrame(
         {
             "open": base,
-            "high": base + 0.5,
-            "low": base - 0.5,
+            "high": base + vol,
+            "low": base - vol,
             "close": base,
         },
         index=times,
@@ -100,3 +102,81 @@ def test_volatility_adjusted_interpolation_non_linear_large_gap(mock_logger):
     assert list(vol_res.columns) == list(linear_res.columns)
     assert not np.allclose(vol_res["close"], linear_res["close"])
     assert vol_res["close"].diff().diff().abs().sum() > 0
+
+
+def test_volatility_adjusted_differs_from_spline(mock_logger):
+    """Ensure volatility adjustment changes the spline result."""
+    pytest.importorskip("pandas_ta")
+    interpolator = _create_interpolator(mock_logger)
+
+    pre = _sample_data("2023-01-01 00:00", 5, slope=1.0, vol=0.5)
+    post = _sample_data("2023-01-01 00:10", 5, slope=2.0, vol=0.5)
+    combined = pd.concat([pre, post])
+
+    time_index = pd.date_range("2023-01-01 00:05", periods=5, freq="1min", tz=UTC)
+
+    gap_info = GapInfo(
+        start_time=time_index[0] - timedelta(minutes=1),
+        end_time=time_index[-1] + timedelta(minutes=1),
+        duration=timedelta(minutes=6),
+        symbol="XRP/USD",
+        data_type="ohlcv",
+        gap_size=len(time_index),
+        preceding_data_quality=1.0,
+        following_data_quality=1.0,
+    )
+
+    spline_res = interpolator._spline_interpolation(combined, time_index)
+    vol_res = interpolator._volatility_adjusted_interpolation(combined, time_index, gap_info)
+
+    assert not np.allclose(vol_res["close"], spline_res["close"])
+
+
+def test_volatility_adjusted_scales_with_volatility(mock_logger):
+    """Higher volatility should lead to larger adjustments."""
+    pytest.importorskip("pandas_ta")
+    interpolator = _create_interpolator(mock_logger)
+
+    # Low volatility dataset
+    pre_low = _sample_data("2023-01-01 00:00", 5, slope=1.0, vol=0.5)
+    post_low = _sample_data("2023-01-01 00:10", 5, slope=2.0, vol=0.5)
+    combined_low = pd.concat([pre_low, post_low])
+    time_low = pd.date_range("2023-01-01 00:05", periods=5, freq="1min", tz=UTC)
+
+    gap_low = GapInfo(
+        start_time=time_low[0] - timedelta(minutes=1),
+        end_time=time_low[-1] + timedelta(minutes=1),
+        duration=timedelta(minutes=6),
+        symbol="XRP/USD",
+        data_type="ohlcv",
+        gap_size=len(time_low),
+        preceding_data_quality=1.0,
+        following_data_quality=1.0,
+    )
+
+    spline_low = interpolator._spline_interpolation(combined_low, time_low)
+    vol_low = interpolator._volatility_adjusted_interpolation(combined_low, time_low, gap_low)
+    dev_low = np.abs(vol_low["close"] - spline_low["close"]).mean()
+
+    # High volatility dataset (wider high/low range)
+    pre_high = _sample_data("2023-01-02 00:00", 5, slope=1.0, vol=2.0)
+    post_high = _sample_data("2023-01-02 00:10", 5, slope=2.0, vol=2.0)
+    combined_high = pd.concat([pre_high, post_high])
+    time_high = pd.date_range("2023-01-02 00:05", periods=5, freq="1min", tz=UTC)
+
+    gap_high = GapInfo(
+        start_time=time_high[0] - timedelta(minutes=1),
+        end_time=time_high[-1] + timedelta(minutes=1),
+        duration=timedelta(minutes=6),
+        symbol="XRP/USD",
+        data_type="ohlcv",
+        gap_size=len(time_high),
+        preceding_data_quality=1.0,
+        following_data_quality=1.0,
+    )
+
+    spline_high = interpolator._spline_interpolation(combined_high, time_high)
+    vol_high = interpolator._volatility_adjusted_interpolation(combined_high, time_high, gap_high)
+    dev_high = np.abs(vol_high["close"] - spline_high["close"]).mean()
+
+    assert dev_high > dev_low


### PR DESCRIPTION
## Summary
- implement volatility adjustment in SimulatedMarketPriceService
- extend gap interpolator tests for spline comparison and volatility scaling

## Testing
- `pytest tests/unit/test_gap_interpolator.py::test_spline_interpolation_non_linear_small_gap tests/unit/test_gap_interpolator.py::test_volatility_adjusted_interpolation_non_linear_large_gap -vv -s`
- `pytest tests/unit/test_gap_interpolator.py::test_volatility_adjusted_differs_from_spline -vv -s` *(skipped: pandas_ta import error)*
- `pytest tests/unit/test_gap_interpolator.py::test_volatility_adjusted_scales_with_volatility -vv -s` *(skipped: pandas_ta import error)*

------
https://chatgpt.com/codex/tasks/task_e_6849e75f48fc8326826e4940696d4f1c