### PR TITLE
Fix PositionAdjustment schema

### DIFF
--- a/gal_friday/dal/alembic_env/versions/20250611_enforce_non_nullable_reconciliation_id.py
+++ b/gal_friday/dal/alembic_env/versions/20250611_enforce_non_nullable_reconciliation_id.py
@@ -1,0 +1,36 @@
+"""Enforce non-nullable reconciliation_id in position_adjustments.
+
+Revision ID: enforce_non_nullable_reconciliation_id
+Revises: add_position_id_to_orders
+Create Date: 2025-06-11 00:00:00.000000
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "enforce_non_nullable_reconciliation_id"
+down_revision = "add_position_id_to_orders"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    """Enforce NOT NULL constraint on reconciliation_id."""
+    op.alter_column(
+        "position_adjustments",
+        "reconciliation_id",
+        existing_type=sa.dialects.postgresql.UUID(as_uuid=True),
+        nullable=False,
+    )
+
+
+def downgrade() -> None:
+    """Revert reconciliation_id to nullable."""
+    op.alter_column(
+        "position_adjustments",
+        "reconciliation_id",
+        existing_type=sa.dialects.postgresql.UUID(as_uuid=True),
+        nullable=True,
+    )

--- a/gal_friday/dal/models/position_adjustment.py
+++ b/gal_friday/dal/models/position_adjustment.py
@@ -17,19 +17,25 @@ class PositionAdjustment(Base):
     __tablename__ = "position_adjustments"
 
     adjustment_id: Mapped[UUID] = mapped_column(
-        UUID(as_uuid=True), primary_key=True, server_default=func.uuid_generate_v4(),
+        UUID(as_uuid=True),
+        primary_key=True,
+        server_default=func.uuid_generate_v4(),
     )
     # reconciliation_id is a ForeignKey to reconciliation_events.reconciliation_id
-    reconciliation_id: Mapped[UUID | None] = mapped_column( # Schema in 001 allows NULL, 003 implies NOT NULL via REFERENCES. Assuming 001 version for FK nullability for now.
-        ForeignKey("reconciliation_events.reconciliation_id"), nullable=True, index=True, # Added index
+    reconciliation_id: Mapped[UUID] = mapped_column(
+        ForeignKey("reconciliation_events.reconciliation_id"),
+        nullable=False,
+        index=True,
     )
-    trading_pair: Mapped[str] = mapped_column(String(20), nullable=False) # From 003, added index
-    adjustment_type: Mapped[str] = mapped_column(String(50), nullable=False) # From 003
+    trading_pair: Mapped[str] = mapped_column(String(20), nullable=False)  # From 003, added index
+    adjustment_type: Mapped[str] = mapped_column(String(50), nullable=False)  # From 003
     old_value: Mapped[Decimal | None] = mapped_column(Numeric(20, 8), nullable=True)
     new_value: Mapped[Decimal | None] = mapped_column(Numeric(20, 8), nullable=True)
     reason: Mapped[str | None] = mapped_column(Text, nullable=True)
     adjusted_at: Mapped[datetime | None] = mapped_column(
-        DateTime, server_default=func.current_timestamp(), index=True, # Added index based on 003
+        DateTime,
+        server_default=func.current_timestamp(),
+        index=True,  # Added index based on 003
     )
 
     # Relationship to ReconciliationEvent
@@ -37,8 +43,8 @@ class PositionAdjustment(Base):
 
     __table_args__ = (
         Index("idx_adjustments_reconciliation", "reconciliation_id"),
-        Index("idx_adjustments_pair", "trading_pair"), # From 003
-        Index("idx_adjustments_timestamp", "adjusted_at"), # From 003
+        Index("idx_adjustments_pair", "trading_pair"),  # From 003
+        Index("idx_adjustments_timestamp", "adjusted_at"),  # From 003
     )
 
     def __repr__(self) -> str:


### PR DESCRIPTION
## Summary
- make `reconciliation_id` on `PositionAdjustment` non-nullable
- add Alembic migration enforcing NOT NULL for `reconciliation_id`

## Testing
- `ruff format gal_friday/dal/alembic_env/versions/20250611_enforce_non_nullable_reconciliation_id.py gal_friday/dal/models/position_adjustment.py`
- `ruff check --fix gal_friday/dal/alembic_env/versions/20250611_enforce_non_nullable_reconciliation_id.py gal_friday/dal/models/position_adjustment.py`
- `mypy gal_friday/dal/models/position_adjustment.py` *(fails: Missing imports)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'yaml')*
- `bandit -r gal_friday` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849fc64922c83269434904f92f181a6