### PR TITLE
Implement Kraken batch order API

### DIFF
--- a/gal_friday/exceptions.py
+++ b/gal_friday/exceptions.py
@@ -170,6 +170,10 @@ class ExecutionError(GalFridayError):
     """Exception raised for errors during order execution."""
 
 
+class ExchangeError(ExecutionError):
+    """Exception raised for exchange API failures."""
+
+
 class ExecutionHandlerError(ExecutionError):
     """Base exception for ExecutionHandler errors."""
 


### PR DESCRIPTION
## Summary
- extend `KrakenExecutionAdapter` with new `place_batch_orders` that calls Kraken's batch API
- include helper `_create_order_payload`
- remove obsolete comment about individual placement
- introduce `ExchangeError` for exchange call failures

## Testing
- `ruff check gal_friday/` *(fails: E902 No such file or directory)*
- `mypy gal_friday/` *(fails: ModuleNotFoundError: No module named 'yaml')*
- `pytest tests/ -v --tb=short` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_6849ff68658483268cf84f34025ade66