### PR TITLE
Add FillEvent and handle fills in websocket client

### DIFF
--- a/gal_friday/core/event_store.py
+++ b/gal_friday/core/event_store.py
@@ -419,6 +419,7 @@ class EventStore:
         from gal_friday.core.events import (
             ClosePositionCommand,
             ExecutionReportEvent,
+            FillEvent,
             MarketDataL2Event,
             MarketDataOHLCVEvent,
             MarketDataTickerEvent,
@@ -439,6 +440,7 @@ class EventStore:
             TradeSignalApprovedEvent,
             TradeSignalRejectedEvent,
             ExecutionReportEvent,
+            FillEvent,
             SystemStateEvent,
             PotentialHaltTriggerEvent,
             ClosePositionCommand,

--- a/gal_friday/core/events.py
+++ b/gal_friday/core/events.py
@@ -323,6 +323,7 @@ class EventType(Enum):
     TRADE_SIGNAL_APPROVED = auto()  # Approved trade signal from RiskManager
     TRADE_SIGNAL_REJECTED = auto()  # Rejected trade signal from RiskManager
     EXECUTION_REPORT = auto()  # Report from ExecutionHandler (fill, error, etc.)
+    FILL = auto()  # Individual trade fill event
     TRADE_OUTCOME_REPORTED = auto()  # Final outcome of a trade
 
     # System & Operational Events
@@ -1146,6 +1147,20 @@ class ExecutionReportEvent(Event):
             timestamp_exchange=params.timestamp_exchange,
             error_message=params.error_message,
         )
+
+
+@dataclass(frozen=True)
+class FillEvent(Event):
+    """Event representing a single trade fill."""
+
+    order_id: str
+    fill_id: str
+    trading_pair: str
+    side: str
+    price: Decimal
+    quantity: Decimal
+    fee: Decimal
+    event_type: EventType = field(default=EventType.FILL, init=False)
 
 
 @dataclass(frozen=True)


### PR DESCRIPTION
## Summary
- introduce `FillEvent` for execution fills
- register `FillEvent` in `EventStore`
- emit `FillEvent` from Kraken WebSocket client when own trades are received

## Testing
- `ruff check gal_friday/core/events.py gal_friday/core/event_store.py gal_friday/execution/websocket_client.py`
- `pytest tests/` *(fails: ModuleNotFoundError for required dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_684a0174ff1883269176eccb3fea60bf