### PR TITLE
Fix model registry export

### DIFF
--- a/gal_friday/model_lifecycle/__init__.py
+++ b/gal_friday/model_lifecycle/__init__.py
@@ -1,5 +1,6 @@
 """Model lifecycle management components."""
 
+from .enums import ModelStage, ModelStatus
 from .experiment_manager import (
     AllocationStrategy,
     ExperimentConfig,
@@ -7,8 +8,8 @@ from .experiment_manager import (
     ExperimentStatus,
     VariantPerformance,
 )
-from .enums import ModelStage, ModelStatus
-from .registry import ModelArtifact, ModelMetadata, Registry
+from .registry import ModelArtifact, ModelMetadata
+from .registry import Registry as ModelRegistry
 from .retraining_pipeline import (
     DriftDetector,
     DriftMetrics,


### PR DESCRIPTION
## Summary
- alias `Registry` as `ModelRegistry` in model lifecycle package

## Testing
- `ruff check gal_friday/model_lifecycle/__init__.py`
- `pytest tests/ -v --tb=short` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_684a023fe0d4832690c3b80c70b08fdd