### PR TITLE
Implement critical alerting for orphaned orders

### DIFF
--- a/gal_friday/core/events.py
+++ b/gal_friday/core/events.py
@@ -1242,6 +1242,28 @@ class APIErrorEvent(Event):
 
 
 @dataclass(frozen=True)
+class CriticalAlertEvent(Event):
+    """Event representing a critical system alert."""
+
+    order_id: str
+    alert_message: str
+    event_type: EventType = field(default=EventType.SYSTEM_ERROR, init=False)
+
+    @classmethod
+    def create(
+        cls, source_module: str, order_id: str, message: str,
+    ) -> "CriticalAlertEvent":
+        """Create a new CriticalAlertEvent instance."""
+        return cls(
+            source_module=source_module,
+            event_id=uuid.uuid4(),
+            timestamp=dt.datetime.now(dt.UTC),
+            order_id=order_id,
+            alert_message=message,
+        )
+
+
+@dataclass(frozen=True)
 class ClosePositionCommand(Event):
     """Command to close an open position, typically triggered during a system HALT."""
 


### PR DESCRIPTION
## Summary
- add `CriticalAlertEvent` for high priority alerts
- wire `PubSubManager` into `OrderPositionIntegrationService`
- publish alert when auto-fixing orders fails
- detect orphaned order references and unlink them when possible

## Testing
- `pre-commit run --files gal_friday/core/events.py gal_friday/execution/order_position_integration.py`
- `ruff check --select E9,F63,F7,F82 gal_friday/core/events.py gal_friday/execution/order_position_integration.py`

------
https://chatgpt.com/codex/tasks/task_e_684a0efdf04483268db7640e68b4ab74