### PR TITLE
Refactor Signal.to_event

### DIFF
--- a/gal_friday/models/signal.py
+++ b/gal_friday/models/signal.py
@@ -46,19 +46,13 @@ class Signal(Base):
             f"strategy_id='{self.strategy_id}', status='{self.status}')>"
         )
 
-    def to_event(self) -> "TradeSignalProposedEvent": # Added to_event with type hints
-        """Converts the Signal object to a TradeSignalProposedEvent."""
-        # Assuming TradeSignalProposedEvent is importable from gal_friday.core.events
-        # import uuid # Already imported
-        # from datetime import datetime # Already imported
-        # from decimal import Decimal # For type conversion if necessary
-        # from gal_friday.core.events import TradeSignalProposedEvent
-
+    def to_event(self) -> "TradeSignalProposedEvent":
+        """Convert this Signal into a TradeSignalProposedEvent."""
         event_data = {
             "source_module": self.__class__.__name__,
-            "event_id": uuid.uuid4(), # New event ID
-            "timestamp": datetime.utcnow(), # Event creation time
-            "signal_id": self.signal_id, # Use the Signal's own ID
+            "event_id": uuid.uuid4(),
+            "timestamp": datetime.utcnow(),
+            "signal_id": self.signal_id,
             "trading_pair": self.trading_pair,
             "exchange": self.exchange,
             "side": self.side,
@@ -68,30 +62,9 @@ class Signal(Base):
             "proposed_tp_price": self.proposed_tp_price,
             "strategy_id": self.strategy_id,
             "triggering_prediction_event_id": self.prediction_event_id,
-            # 'triggering_prediction' field in event might need more data if available
-            "triggering_prediction": {"value": self.prediction_value} if self.prediction_value is not None else None,
+            "triggering_prediction": (
+                {"value": self.prediction_value} if self.prediction_value is not None else None
+            ),
         }
-        # In a real implementation:
-        # from gal_friday.core.events import TradeSignalProposedEvent
-        # return TradeSignalProposedEvent(**event_data)
 
-        # Returning dict for now
-        # return TradeSignalProposedEvent(**event_data) # Old way
-
-        # Explicitly pass arguments
-        return TradeSignalProposedEvent(
-            source_module=self.__class__.__name__,
-            event_id=uuid.uuid4(), # New event_id for this event
-            timestamp=datetime.utcnow(), # Event's own creation time
-            signal_id=self.signal_id, # This is the ID of the signal itself
-            trading_pair=self.trading_pair,
-            exchange=self.exchange,
-            side=self.side,
-            entry_type=self.entry_type,
-            proposed_entry_price=self.proposed_entry_price, # Ensure Decimal | None
-            proposed_sl_price=self.proposed_sl_price, # Ensure Decimal
-            proposed_tp_price=self.proposed_tp_price, # Ensure Decimal
-            strategy_id=self.strategy_id,
-            triggering_prediction_event_id=self.prediction_event_id, # Ensure uuid.UUID | None
-            triggering_prediction={"value": self.prediction_value} if self.prediction_value is not None else None,
-        )
+        return TradeSignalProposedEvent(**event_data)


### PR DESCRIPTION
## Summary
- clean up `Signal.to_event` construction logic

## Testing
- `ruff check --fix gal_friday/models/signal.py`
- `mypy gal_friday/models/signal.py` *(fails: Cannot find implementation or library stub for module named 'sqlalchemy')*
- `pytest tests/unit/test_fill_execution_events.py::TestFillExecutionEvents::test_to_event_success` *(fails: ModuleNotFoundError: No module named 'yaml')*
- `bandit -r gal_friday/models/signal.py` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a12f1a7208326a0fe0ece33cf213a